### PR TITLE
Fix printing in latest Atom version

### DIFF
--- a/lib/printer.coffee
+++ b/lib/printer.coffee
@@ -27,14 +27,7 @@ module.exports = AtomPrinter =
 
     document.body.appendChild(iframe)
 
-    close = ->
-      document.body.removeChild(iframe)
-
     content = iframe.contentWindow
-
-    content.onbeforeunload = close
-    content.onafterprint = close
-
     content.document.body.className = document.body.className
     @addThemeStyles(content.document)
 
@@ -45,6 +38,7 @@ module.exports = AtomPrinter =
 
     content.document.body.appendChild(container)
     content.print()
+    document.body.removeChild(iframe)
 
   addEditorContent: (container) ->
     editor = atom.workspace.getActiveTextEditor()

--- a/lib/printer.coffee
+++ b/lib/printer.coffee
@@ -1,5 +1,4 @@
 {CompositeDisposable} = require 'atom'
-_ = null
 
 module.exports = AtomPrinter =
   atomPrinterView: null
@@ -19,8 +18,6 @@ module.exports = AtomPrinter =
   serialize: ->
 
   print: ->
-    _ ?= require 'lodash'
-
     iframe = document.createElement('iframe')
 
     iframe.style.visibility = 'hidden'
@@ -63,8 +60,8 @@ module.exports = AtomPrinter =
 
   getThemeHTML: ->
     themes = atom.themes.getActiveThemes()
-    syntaxTheme = _.find themes, (theme) -> theme.metadata.theme is 'syntax'
-    "<style>#{sheet[1] for sheet in syntaxTheme.stylesheets}</style>"
+    syntaxThemes = themes.filter (theme) -> theme.metadata.theme is 'syntax'
+    "<style>#{sheet[1] for sheet in syntaxTheme.stylesheets for syntaxTheme in syntaxThemes}</style>"
 
   updateScopeStack: (scopeStack, desiredScopeDescriptor) ->
     html = ""

--- a/package.json
+++ b/package.json
@@ -10,8 +10,5 @@
   "license": "MIT",
   "engines": {
     "atom": ">=0.174.0 <2.0.0"
-  },
-  "dependencies": {
-    "lodash": "^3.2.0"
   }
 }


### PR DESCRIPTION
The main change here generates DOM nodes instead of using HTML code - that's more secure and compatible with current Atom versions. The other two changes:

* Without the (pretty much unnecessary) lodash dependency the repository can simply be checked out into ~/.atom/packages and will work.
* Frame is being removed unconditionally, so that there is no longer a memory leak when printing is aborted for example.